### PR TITLE
chore: removed deprecated S3GW from website

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,15 +35,6 @@ const features = [
       </>
     ),
   },
-  {
-    title: 'SUSE COSI Driver',
-    repoURL: 'https://github.com/aquarist-labs/s3gw-cosi-driver',
-    description: (
-      <>
-        Official COSI driver for SUSE s3gw.
-      </>
-    ),
-  },
 ];
 
 function Feature({ repoURL, title, description }) {


### PR DESCRIPTION
[Aquarist Labs](https://github.com/aquarist-labs) org was archived, so there is no active development on the S3GW COSI Driver.